### PR TITLE
[#15] SEO 최적화를 위한 sitemap 동적 생성 파일, robots.txt 추가

### DIFF
--- a/src/app/robots.txt
+++ b/src/app/robots.txt
@@ -1,0 +1,5 @@
+User-Agent: *
+Allow: /
+Disallow: /private/
+
+Sitemap: https://heeji.dev/sitemap.xml

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,40 @@
+import { getAllPosts } from '@/service/post';
+import { MetadataRoute } from 'next';
+
+const baseURL = 'https://heeji.dev';
+
+type SitemapEntry = {
+  url: string;
+  lastModified?: string | Date;
+};
+
+const createUrl = (p: string) => baseURL + p;
+
+const rootEntry: SitemapEntry = {
+  url: baseURL,
+  lastModified: new Date(),
+};
+
+const postListEntry: SitemapEntry = {
+  url: createUrl('/posts'),
+  lastModified: new Date(),
+};
+
+const aboutPageEntry: SitemapEntry = {
+  url: createUrl('/about'),
+  lastModified: new Date(),
+};
+
+async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const posts = await getAllPosts();
+
+  const postEntries =
+    posts?.map((post) => ({
+      url: createUrl(`/posts/${post.id}`),
+      lastModified: new Date(),
+    })) ?? [];
+
+  return [rootEntry, postListEntry, aboutPageEntry, ...postEntries];
+}
+
+export default sitemap;


### PR DESCRIPTION
## 개요
- 크롤러가 웹사이트를 더 잘 이해하도록

## 구현내용
- sitemap.ts에서 post 목록 불러온 다음, id로 url 추가
- robots.txt 기본 파일 추가

Resolves #15 