### PR TITLE
feat: Giscus 댓글·다크모드 토글 복구

### DIFF
--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Markdown from '@/components/Markdown';
+import Giscus from '@/components/Giscus';
 import {
   POST_TYPE_LABEL,
   getPostBySlug,
@@ -81,6 +82,10 @@ export default function PostDetailPage({ params }: { params: Param }) {
       </header>
 
       <Markdown code={post.mdx} />
+
+      <section className='border-t border-base-200 pt-8 dark:border-base-700'>
+        <Giscus />
+      </section>
     </article>
   );
 }

--- a/src/components/Giscus.tsx
+++ b/src/components/Giscus.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export default function Giscus() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [theme, setTheme] = useState(
+    typeof window !== 'undefined'
+      ? document.documentElement.classList.contains('dark')
+        ? 'dark'
+        : 'light'
+      : 'light'
+  );
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      const newTheme = document.documentElement.classList.contains('dark')
+        ? 'dark'
+        : 'light';
+      setTheme(newTheme);
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!ref.current || ref.current.hasChildNodes()) return;
+
+    const scriptElem = document.createElement('script');
+    scriptElem.src = 'https://giscus.app/client.js';
+    scriptElem.async = true;
+    scriptElem.crossOrigin = 'anonymous';
+
+    scriptElem.setAttribute('data-repo', 'heeji289/heeji.dev');
+    scriptElem.setAttribute('data-repo-id', 'R_kgDOMEPXTw');
+    scriptElem.setAttribute('data-category', 'General');
+    scriptElem.setAttribute('data-category-id', 'DIC_kwDOMEPXT84CgXIB');
+    scriptElem.setAttribute('data-mapping', 'og:title');
+    scriptElem.setAttribute('data-strict', '0');
+    scriptElem.setAttribute('data-reactions-enabled', '1');
+    scriptElem.setAttribute('data-emit-metadata', '0');
+    scriptElem.setAttribute('data-input-position', 'bottom');
+    scriptElem.setAttribute('data-theme', theme);
+    scriptElem.setAttribute('data-lang', 'ko');
+
+    ref.current.appendChild(scriptElem);
+  }, [theme]);
+
+  // https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#isetconfigmessage
+  useEffect(() => {
+    const iframe = document.querySelector<HTMLIFrameElement>(
+      'iframe.giscus-frame'
+    );
+    iframe?.contentWindow?.postMessage(
+      { giscus: { setConfig: { theme } } },
+      'https://giscus.app'
+    );
+  }, [theme]);
+
+  return <section ref={ref} />;
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import Logo from '@/components/Logo';
+import ThemeToggle from '@/components/ThemeToggle';
 
 const navItems = [
   { href: '/posts', label: 'posts' },
@@ -26,22 +27,26 @@ export default function Nav() {
         <Logo className='h-7 w-7 transition-transform hover:-translate-y-px' />
       </Link>
 
-      <ul className='flex flex-wrap items-center gap-5 text-base-500 dark:text-base-400'>
-        {navItems.map((item) => (
-          <li key={item.href}>
-            <Link
-              href={item.href}
-              className={`inline-block py-1 font-mono lowercase tracking-tight transition-colors ${
-                isActive(item.href)
-                  ? 'text-info-600 dark:text-info-400'
-                  : 'text-base-500 dark:text-base-400'
-              } hover:text-info-600 dark:hover:text-info-400`}
-            >
-              {item.label}
-            </Link>
-          </li>
-        ))}
-      </ul>
+      <div className='flex items-center gap-5'>
+        <ul className='flex flex-wrap items-center gap-5 text-base-500 dark:text-base-400'>
+          {navItems.map((item) => (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                className={`inline-block py-1 font-mono lowercase tracking-tight transition-colors ${
+                  isActive(item.href)
+                    ? 'text-info-600 dark:text-info-400'
+                    : 'text-base-500 dark:text-base-400'
+                } hover:text-info-600 dark:hover:text-info-400`}
+              >
+                {item.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+
+        <ThemeToggle />
+      </div>
     </nav>
   );
 }

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    setIsDark(document.documentElement.classList.contains('dark'));
+  }, []);
+
+  const handleToggle = () => {
+    const next = !document.documentElement.classList.contains('dark');
+    document.documentElement.classList.toggle('dark', next);
+    window.localStorage.setItem('theme', next ? 'dark' : 'light');
+    setIsDark(next);
+  };
+
+  return (
+    <button
+      type='button'
+      onClick={handleToggle}
+      aria-label='테마 전환'
+      className='inline-flex h-7 w-7 items-center justify-center rounded-md text-base-500 transition-colors hover:text-info-600 dark:text-base-400 dark:hover:text-info-400'
+    >
+      {isDark ? (
+        // sun
+        <svg
+          width='16'
+          height='16'
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='2'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          aria-hidden='true'
+        >
+          <circle cx='12' cy='12' r='4' />
+          <path d='M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41' />
+        </svg>
+      ) : (
+        // moon
+        <svg
+          width='16'
+          height='16'
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='2'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          aria-hidden='true'
+        >
+          <path d='M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z' />
+        </svg>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## 개요

전면 리디자인(#43)이 main에 머지되면서 빠졌던 v1 기능 두 가지를 새 디자인에 맞춰 복구합니다.

## 변경
- **Giscus 댓글**: 글 상세(`/posts/[slug]`) 하단에 복구. 레포 `heeji289/heeji.dev`, 다크모드 연동(테마 변경 시 자동 반영).
- **다크모드 토글**: Nav 우측에 해/달 토글 버튼 추가. 의존성 없이 인라인 SVG로 구현, `localStorage`에 테마 저장.

## 제외
- about 경력 타임라인은 복구하지 않음(요청). about은 미니멀 상태 유지.

## 테스트
- `bunx tsc --noEmit` 통과
- `bun run build` 성공 (39페이지)
- 로컬 라우트 확인: `/`, `/posts`, `/posts/[slug]`, `/tags`, `/tags/[tag]`, `/about` 모두 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)